### PR TITLE
Use F30 as the base image

### DIFF
--- a/downloads/firefox/installs.ini
+++ b/downloads/firefox/installs.ini
@@ -1,0 +1,4 @@
+[11457493C5A56847]
+Default=abs780mn.default
+Locked=1
+

--- a/ks.cfg
+++ b/ks.cfg
@@ -398,6 +398,7 @@ cp -r orca/* /etc/skel/.local/share/orca/
 cp mimeapps.list /home/agora/.config/
 mkdir -p /etc/skel/.config
 cp mimeapps.list /etc/skel/.config/
+mkdir -p /home/agora/Plocha
 cp napoveda.txt /home/agora/Plocha/
 cp napoveda.txt /etc/skel/
 mkdir -p /home/agora/.mozilla/firefox
@@ -407,10 +408,6 @@ cp -r firefox/* /etc/skel/.mozilla/firefox/
 chown -R agora:agora /home/agora/
 cd /tmp
 rm -rf /tmp/fegora
-#downgrade mate because of problems with panel
-dnf -y downgrade mate\*
-#prevent mate upgrade
-echo 'exclude=mate*' >> /etc/dnf/dnf.conf
 #configure festival
 sed 's/#AddModule "festival"                 "sd_festival"  "festival\.conf"/AddModule "festival"                 "sd_festival"  "festival\.conf"/' /etc/speech-dispatcher/speechd.conf
 echo "(set! voice_default 'voice_czech_dita)" > /etc/skel/.festivalrc

--- a/ks.cfg
+++ b/ks.cfg
@@ -10,18 +10,18 @@ install
 # clear partitions
 clearpart --all --drives=sda
 # add repositories as sources of packages
-repo --name=fedora --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-29&arch=x86_64
-repo --name=updates --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f29&arch=x86_64
-url --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-29&arch=x86_64
+repo --name=fedora --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-30&arch=x86_64
+repo --name=updates --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=updates-released-f30&arch=x86_64
+url --mirrorlist=https://mirrors.fedoraproject.org/mirrorlist?repo=fedora-30&arch=x86_64
 #rpm fusion repos
-repo --name=rpmfusion-free-released --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-29&arch=x86_64
-repo --name=rpmfusion-free-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-updates-released-29&arch=x86_64
-repo --name=rpmfusion-nonfree --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-29&arch=x86_64 --includepkgs=rpmfusion-nonfree-release
-repo --name=rpmfusion-nonfree-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-updates-released-29&arch=x86_64 --includepkgs=rpmfusion-nonfree-release
+repo --name=rpmfusion-free-released --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-30&arch=x86_64
+repo --name=rpmfusion-free-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=free-fedora-updates-released-30&arch=x86_64
+repo --name=rpmfusion-nonfree --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-30&arch=x86_64 --includepkgs=rpmfusion-nonfree-release
+repo --name=rpmfusion-nonfree-updates --mirrorlist=https://mirrors.rpmfusion.org/mirrorlist?repo=nonfree-fedora-updates-released-30&arch=x86_64 --includepkgs=rpmfusion-nonfree-release
 #festival repo
-repo --install --name=Copr-repo-for-festival-reborn-owned-by-tyrylu --baseurl=https://copr-be.cloud.fedoraproject.org/results/tyrylu/festival-reborn/fedora-29-x86_64/
+repo --install --name=Copr-repo-for-festival-reborn-owned-by-tyrylu --baseurl=https://copr-be.cloud.fedoraproject.org/results/tyrylu/festival-reborn/fedora-30-x86_64/
 #fegora repo
-repo --install --name=Copr-repo-for-fegora-apps-owned-by-tyrylu --baseurl=https://copr-be.cloud.fedoraproject.org/results/tyrylu/fegora-apps/fedora-29-x86_64/
+repo --install --name=Copr-repo-for-fegora-apps-owned-by-tyrylu --baseurl=https://copr-be.cloud.fedoraproject.org/results/tyrylu/fegora-apps/fedora-30-x86_64/
 
 # Keyboard layouts
 keyboard --vckeymap=cz --xlayouts='cz'

--- a/prepare_iso.sh
+++ b/prepare_iso.sh
@@ -3,14 +3,14 @@
 mountdir=$(mktemp -d)
 fedoradir=$(mktemp -d)
 
-if [ ! -e 'Fedora-Everything-netinst-x86_64-29-1.2.iso' ]
+if [ ! -e 'Fedora-Everything-netinst-x86_64-30-1.2.iso' ]
 then echo "downloading ISO and checksums..."
-wget 'https://mirror.karneval.cz/pub/linux/fedora/linux/releases/29/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-29-1.2.iso'
-wget 'https://mirror.karneval.cz/pub/linux/fedora/linux/releases/29/Everything/x86_64/iso/Fedora-Everything-29-1.2-x86_64-CHECKSUM'
-sha256sum -c 'Fedora-Everything-29-1.2-x86_64-CHECKSUM'
+wget 'https://mirror.karneval.cz/pub/linux/fedora/linux/releases/30/Everything/x86_64/iso/Fedora-Everything-netinst-x86_64-30-1.2.iso'
+wget 'https://mirror.karneval.cz/pub/linux/fedora/linux/releases/30/Everything/x86_64/iso/Fedora-Everything-30-1.2-x86_64-CHECKSUM'
+sha256sum -c 'Fedora-Everything-30-1.2-x86_64-CHECKSUM'
 fi
 echo "mounting ISO..."
-fuseiso 'Fedora-Everything-netinst-x86_64-29-1.2.iso' $mountdir
+fuseiso 'Fedora-Everything-netinst-x86_64-30-1.2.iso' $mountdir
 echo "copying ISO contents..."
 cp -a $mountdir/* $fedoradir
 echo "unmounting ISO..."
@@ -20,7 +20,7 @@ echo "copying kickstart file..."
 cp ks.cfg $fedoradir
 echo "modifying isolinux.cfg..."
 sed -i '/menu default/d' $fedoradir/isolinux/isolinux.cfg
-sed -i '/label linux/i label kickstart\n  menu label \^Install accessible Fedora 29 Mate\n  menu default\n  kernel vmlinuz\n  append initrd=initrd\.img inst\.ks=hd:LABEL=fedora console=ttyS0,9600\n' $fedoradir/isolinux/isolinux.cfg
+sed -i '/label linux/i label kickstart\n  menu label \^Install accessible Fedora 30 Mate\n  menu default\n  kernel vmlinuz\n  append initrd=initrd\.img inst\.ks=hd:LABEL=fedora console=ttyS0,9600\n' $fedoradir/isolinux/isolinux.cfg
 echo "repacking iso..."
 mkisofs -o fegora.iso -b isolinux/isolinux.bin -c isolinux/boot.cat -no-emul-boot -boot-load-size 4 -boot-info-table -J -R -V fedora $fedoradir
 echo "cleaning up..."


### PR DESCRIPTION
This PR are the changes needed to use F30 for the image.
Changes (excluding replacements of 29 with 30):
* Dropped the downgrade of mate packages
* The desktop directory needs to be created by the postinstall script
* Firefox needs an installs.ini in the data folder, otherwise it happily creates a new profile